### PR TITLE
Adds ScalaTest and Travis CI validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: scala
+
+# These directories are cached to S3 at the end of the build
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/
+
+jdk:
+  - oraclejdk8
+
+script:
+  ## This runs the template with the default parameters, and runs test within the templated app.
+  - sbt -Dfile.encoding=UTF8 -J-XX:ReservedCodeCacheSize=256M test
+
+  # Tricks to avoid unnecessary cache updates
+  - find $HOME/.sbt -name "*.lock" | xargs rm
+  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm

--- a/README.markdown
+++ b/README.markdown
@@ -6,7 +6,9 @@ sbt new scala/scala-seed.g8
 
 License
 -------
-This template distributed is under [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/),
-equivalent of public domain.
+Written in 2016 by Lightbend, Inc.
+To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to
+this template to the public domain worldwide. This template is distributed without any warranty.
+See <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 [g8]: http://www.foundweekends.org/giter8/

--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,7 @@
 This is a [Giter8][g8] template for Scala
 
 ```
-sbt new eed3si9n/scala-seed.g8
+sbt new scala/scala-seed.g8
 ```
 
 License

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,9 @@
 // See http://www.foundweekends.org/giter8/testing.html#Using+the+Giter8Plugin for more details.
 lazy val root = (project in file(".")).
   settings(
+    test in Test := {
+      val _ = (g8Test in Test).toTask("").value
+    },
     scriptedLaunchOpts ++= List("-Xms1024m", "-Xmx1024m", "-XX:ReservedCodeCacheSize=128m", "-XX:MaxPermSize=256m", "-Xss2m", "-Dfile.encoding=UTF-8"),
     resolvers += Resolver.url("typesafe", url("http://repo.typesafe.com/typesafe/ivy-releases/"))(Resolver.ivyStylePatterns)
   )

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,9 +1,11 @@
-// give the user a nice default project!
+import Dependencies._
+
 lazy val root = (project in file(".")).
   settings(
     inThisBuild(List(
       organization := "com.example",
       scalaVersion := "2.12.0"
     )),
-    name := "Hello"
+    name := "Hello",
+    libraryDependencies += scalaTest % Test
   )

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,2 +1,2 @@
 name=My Something Project
-description=Say something about this template.
+description=Minimum Scala build.

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -1,0 +1,5 @@
+import sbt._
+
+object Dependencies {
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.0"
+}

--- a/src/main/g8/src/main/scala/Hello.scala
+++ b/src/main/g8/src/main/scala/Hello.scala
@@ -1,3 +1,0 @@
-object Hello extends App {
-  println("hello")
-}

--- a/src/main/g8/src/main/scala/example/Hello.scala
+++ b/src/main/g8/src/main/scala/example/Hello.scala
@@ -1,0 +1,9 @@
+package example
+
+object Hello extends Greeting with App {
+  println(greeting)
+}
+
+trait Greeting {
+  lazy val greeting: String = "hello"
+}

--- a/src/main/g8/src/test/scala/example/HelloSpec.scala
+++ b/src/main/g8/src/test/scala/example/HelloSpec.scala
@@ -1,0 +1,9 @@
+package example
+
+import org.scalatest._
+
+class HelloSpec extends FlatSpec with Matchers {
+  "The Hello object" should "say hello" in {
+    Hello.greeting shouldEqual "hello"
+  }
+}


### PR DESCRIPTION
This adds ScalaTest into the template, which make it feature parity with "minimal-scala" Activator template (https://github.com/typesafehub/activator-minimal-scala).

This also adds Travis CI configuration to run the actual test to make sure the template is runnable.
https://travis-ci.org/eed3si9n/scala-seed.g8/builds/173063830
