### PR TITLE
Update to sbt-giter8 0.8.0, use maven(stable)

### DIFF
--- a/project/giter8.sbt
+++ b/project/giter8.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.7.1")
+addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.8.0")

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -4,7 +4,7 @@ lazy val root = (project in file(".")).
   settings(
     inThisBuild(List(
       organization := "com.example",
-      scalaVersion := "2.12.2",
+      scalaVersion := "$scala_version$",
       version      := "0.1.0-SNAPSHOT"
     )),
     name := "Hello",

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,2 +1,4 @@
 name=Scala Seed Project
 description=A minimal Scala project.
+scala_version = maven(org.scala-lang, scala-library, stable)
+scalatest_version = maven(org.scalatest, scalatest_2.12, stable)

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -1,5 +1,5 @@
 import sbt._
 
 object Dependencies {
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.1"
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "$scalatest_version$"
 }


### PR DESCRIPTION
Updates sbt-giter8 to 0.8.0
Uses scala_version as the latest stable maven version.
Sets up scalatest as latest stable version.