### PR TITLE
Use latest sbt, latest Scala, latest ScalaTest

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -4,7 +4,7 @@ lazy val root = (project in file(".")).
   settings(
     inThisBuild(List(
       organization := "com.example",
-      scalaVersion := "2.12.2",
+      scalaVersion := "2.12.3",
       version      := "0.1.0-SNAPSHOT"
     )),
     name := "Hello",

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -1,5 +1,5 @@
 import sbt._
 
 object Dependencies {
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.1"
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.3"
 }

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16


### PR DESCRIPTION
This pull request upgrade dependencies to latest versions:

 - scala 2.12.3 was released on Jul 26, 2017
 - sbt 0.13.16 was released on Jul 26, 2017
 - scalatest 3.0.3 was released on Apr 20, 2017
