### PR TITLE
Update sbt and scalatest version

### DIFF
--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -1,5 +1,5 @@
 import sbt._
 
 object Dependencies {
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.3"
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.4"
 }

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.1.0


### PR DESCRIPTION
Current sbt version 0.13.16 was released on July 26, 2017.
Last sbt version 1.1.0 was released on January 5, 2018.

Scalatest 3.0.3 was released on April 20, 2017.
Scalatest 3.0.4 was released on October 6, 2017.

Closes #16.