### PR TITLE
[2.12.x] Update Scalatest to 3.0.8

### DIFF
--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -1,5 +1,5 @@
 import sbt._
 
 object Dependencies {
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.5"
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.8"
 }


### PR DESCRIPTION
This updates Scalatest library from `3.0.5` to `3.0.8`.