### PR TITLE
use the Scala org's Travis-CI template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,16 @@
-sudo: false
-dist: xenial
-group: stable
+version: ~> 1.0 # needed for imports
+
+import: scala/scala-dev:travis/default.yml
 
 language: scala
 
 env:
   - ADOPTOPENJDK=8
 
-before_install:
-  # adding $HOME/.sdkman to cache would create an empty directory, which interferes with the initial installation
-  - "[[ -d $HOME/.sdkman/bin/ ]] || rm -rf $HOME/.sdkman/"
-  - curl -sL https://get.sdkman.io | bash
-  - echo sdkman_auto_answer=true > $HOME/.sdkman/etc/config
-  - source "$HOME/.sdkman/bin/sdkman-init.sh"
-
-install:
-  - sdk install java $(sdk list java | grep -o "$ADOPTOPENJDK\.[0-9\.]*hs-adpt" | head -1)
-  - unset JAVA_HOME
-  - java -Xmx32m -version
-  - javac -J-Xmx32m -version
-
 script:
   ## This runs the template with the default parameters, and runs test within the templated app.
   - sbt -Dfile.encoding=UTF8 -J-XX:ReservedCodeCacheSize=256M test
 
-before_cache:
-  - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
-  - find $HOME/.sbt  -name "*.lock"               -delete
-
-cache:
-  directories:
-    - $HOME/.ivy2/cache
-    - $HOME/.sbt/boot
-    - $HOME/.sdkman
+notifications:
+  email:
+    - seth.tisue@lightbend.com


### PR DESCRIPTION
benefits:
* reduced maintenance, by sharing config between repos
* reduce Maven Central 403's by having correct caching config

prompted by recent 403 trouble