### PR TITLE
Add .bsp dir to gitignore

### DIFF
--- a/src/main/g8/.gitignore
+++ b/src/main/g8/.gitignore
@@ -1,1 +1,2 @@
+/.bsp/
 target/


### PR DESCRIPTION
Since the template uses sbt 1.4+, this is a direct product of the project build.