### PR TITLE
refactor: switch testing framework to munit

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -8,7 +8,7 @@ ThisBuild / organizationName := "example"
 lazy val root = (project in file("."))
   .settings(
     name := "$name$",
-    libraryDependencies += scalaTest % Test
+    libraryDependencies += munit % Test
   )
 
 // See https://www.scala-sbt.org/1.x/docs/Using-Sonatype.html for instructions on how to publish to Sonatype.

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -1,5 +1,5 @@
 import sbt._
 
 object Dependencies {
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.11"
+  lazy val munit = "org.scalameta" %% "munit" % "0.7.29"
 }

--- a/src/main/g8/src/test/scala/example/HelloSpec.scala
+++ b/src/main/g8/src/test/scala/example/HelloSpec.scala
@@ -1,10 +1,7 @@
 package example
 
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
-
-class HelloSpec extends AnyFlatSpec with Matchers {
-  "The Hello object" should "say hello" in {
-    Hello.greeting shouldEqual "hello"
+class HelloSpec extends munit.FunSuite {
+  test("say hello") {
+    assertEquals(Hello.greeting, "hello")
   }
 }


### PR DESCRIPTION
Since the Scala Toolkit will be using munit, I think it's a good idea to support this by ensuring the g8 templates are also using it.